### PR TITLE
script: use ENUM_P_TYPE_ARM on ARM machine

### DIFF
--- a/scripts/sign_rproc_fw.py
+++ b/scripts/sign_rproc_fw.py
@@ -8,6 +8,7 @@ try:
     from elftools.elf.elffile import ELFFile
     from elftools.elf.sections import SymbolTableSection
     from elftools.elf.enums import ENUM_P_TYPE_BASE
+    from elftools.elf.enums import ENUM_P_TYPE_ARM
     from elftools.elf.enums import *
 except ImportError:
     print("""
@@ -118,13 +119,18 @@ class SegmentHash(object):
             h = SHA256.new()
             segment = self.img.get_segment(i)
             seg.header = self.img.get_segment(i).header
+            machine = self.img.get_machine_arch()
             logging.debug("compute hash for segment offset %s" % seg.header)
             h.update(segment.data())
             seg.hash = h.digest()
             logging.debug("hash computed: %s" % seg.hash)
             del h
-            struct.pack_into('<I', self._bufview_, self._offset,
-                             ENUM_P_TYPE_BASE[seg.header.p_type])
+            if machine == "ARM":
+                struct.pack_into('<I', self._bufview_, self._offset,
+                                 ENUM_P_TYPE_ARM[seg.header.p_type])
+            else:
+                struct.pack_into('<I', self._bufview_, self._offset,
+                                 ENUM_P_TYPE_BASE[seg.header.p_type])
             self._offset += 4
             struct.pack_into('<7I', self._bufview_, self._offset,
                              seg.header.p_offset, seg.header.p_vaddr,


### PR DESCRIPTION
ENUM_P_TYPE_ARM is not aware of PT_ARM_EXIDX, and
sign_rproc_fw fail to generate signature for these firmwares:

Traceback (most recent call last):
  File "/home/julien/src/stm32/optee_os/scripts/sign_rproc_fw.py", line 416, in <module>
    main()
  File "/home/julien/src/stm32/optee_os/scripts/sign_rproc_fw.py", line 344, in main
    hash = hash_table.get_table()
  File "/home/julien/src/stm32/optee_os/scripts/sign_rproc_fw.py", line 127, in get_table
    ENUM_P_TYPE_BASE[seg.header.p_type])
KeyError: 'PT_ARM_EXIDX'

instead read the machine type and load the correct enum for
ARM machine.

Tested with a Zephyr blinky demo on a cortex-r7 platform.

Signed-off-by: Julien Massot <julien.massot@iot.bzh>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
